### PR TITLE
Implement `call_rpc_method()` in `ClientCommandSender`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ simple_logger = { git = "https://github.com/fvacek/rust-simple_logger.git", bran
 
 [dependencies]
 shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs", branch = "master", version = "3.0.10" }
-shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs", branch = "master", version = "3.0.5" }
+shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs", branch = "master", version = "3.0.7" }
 futures = "0.3.29"
 futures-time = "3.0.0"
 futures-net = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ simple_logger = { git = "https://github.com/fvacek/rust-simple_logger.git", bran
 
 [dependencies]
 shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs", branch = "master", version = "3.0.10" }
-shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs", branch = "master", version = "3.0.4" }
+shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs", branch = "master", version = "3.0.5" }
 futures = "0.3.29"
 futures-time = "3.0.0"
 futures-net = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.4", features = ["derive"] }
 simple_logger = { git = "https://github.com/fvacek/rust-simple_logger.git", branch = "main", features = ["stderr"] }
 
 [dependencies]
-shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs", branch = "master", version = "3.0.10" }
+shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs", branch = "master", version = "3.0.11" }
 shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs", branch = "master", version = "3.0.7" }
 futures = "0.3.29"
 futures-time = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvclient"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ clap = { version = "4.4", features = ["derive"] }
 simple_logger = { git = "https://github.com/fvacek/rust-simple_logger.git", branch = "main", features = ["stderr"] }
 
 [dependencies]
-shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs", branch = "master", version = "3.0.4" }
-shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs", branch = "master", version = "3.0.0" }
+shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs", branch = "master", version = "3.0.10" }
+shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs", branch = "master", version = "3.0.4" }
 futures = "0.3.29"
 futures-time = "3.0.0"
 futures-net = "0.6.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -187,6 +187,17 @@ pub enum ClientEvent {
 
 pub struct ClientEventsReceiver(BroadcastReceiver<ClientEvent>);
 
+impl futures::Stream for ClientEventsReceiver {
+    type Item = ClientEvent;
+
+   fn poll_next(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Option<Self::Item>> {
+       self.get_mut().0.poll_next_unpin(cx)
+   }
+   fn size_hint(&self) -> (usize, Option<usize>) {
+       self.0.size_hint()
+   }
+}
+
 impl ClientEventsReceiver {
     pub async fn wait_for_event(&mut self) -> Result<ClientEvent, RecvError> {
         loop {

--- a/src/client.rs
+++ b/src/client.rs
@@ -74,19 +74,63 @@ impl Drop for Subscriber {
 }
 
 #[derive(Clone,Debug)]
-pub enum CallRpcMethodError {
-    CommunicationError(String),
-    DataError(String),
+pub enum CallRpcMethodErrorKind {
+    // The receive channel got closed before the response received
+    ConnectionClosed,
+    // Received frame could not be parsed to an RpcMessage
+    InvalidMessage(String),
+    // Got an error instead of a result
+    RpcError(RpcError),
+    // Could not convert result to target data type
+    ResultTypeMismatch(String),
+}
+
+impl std::fmt::Display for CallRpcMethodErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let err_msg = match self {
+            CallRpcMethodErrorKind::ConnectionClosed => "Connection closed",
+            CallRpcMethodErrorKind::InvalidMessage(msg) => msg,
+            CallRpcMethodErrorKind::RpcError(err) => &err.to_string(),
+            CallRpcMethodErrorKind::ResultTypeMismatch(msg) => msg,
+        };
+        write!(f, "{}", err_msg)
+    }
+}
+
+#[derive(Clone,Debug)]
+pub struct CallRpcMethodError {
+    path: String,
+    method: String,
+    error: CallRpcMethodErrorKind,
+}
+
+impl CallRpcMethodError {
+    fn new(path: &str, method: &str, error: CallRpcMethodErrorKind) -> Self {
+        Self {
+            path: path.to_owned(),
+            method: method.to_owned(),
+            error
+        }
+    }
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+    pub fn method(&self) -> &str {
+        &self.method
+    }
+    pub fn error(&self) -> &CallRpcMethodErrorKind {
+        &self.error
+    }
+
 }
 
 impl std::fmt::Display for CallRpcMethodError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CallRpcMethodError::CommunicationError(msg) =>
-                write!(f, "{}", msg),
-            CallRpcMethodError::DataError(msg) =>
-                write!(f, "{}", msg),
-        }
+        write!(f, "RPC call on path `{path}`, method `{method}`, error: {error}",
+            path = self.path,
+            method = self.method,
+            error = self.error,
+        )
     }
 }
 
@@ -120,10 +164,6 @@ impl ClientCommandSender {
         self.do_rpc_call_param(shvpath, method, None)
     }
 
-    fn format_call_rpc_err(path: &str, method: &str, error: impl std::fmt::Display) -> String {
-        format!("RPC call on path `{path}`, method `{method}`, error: {error}")
-    }
-
     pub async fn call_dir(&self, path: &str, param: DirParam) -> Result<DirResult, CallRpcMethodError> {
         self.call_dir_into(path, param).await
     }
@@ -149,8 +189,10 @@ impl ClientCommandSender {
             .await
             .and_then(|dir_res|
                 T::try_from(dir_res).map_err(|e|
-                    CallRpcMethodError::DataError(
-                        Self::format_call_rpc_err(path, METH_DIR, e)
+                    CallRpcMethodError::new(
+                        path,
+                        METH_DIR,
+                        CallRpcMethodErrorKind::ResultTypeMismatch(e.to_string())
                     )
                 )
             )
@@ -177,8 +219,10 @@ impl ClientCommandSender {
             .await
             .and_then(|ls_res|
                 T::try_from(ls_res).map_err(|e|
-                    CallRpcMethodError::DataError(
-                        Self::format_call_rpc_err(path, METH_LS, e)
+                    CallRpcMethodError::new(
+                        path,
+                        METH_LS,
+                        CallRpcMethodErrorKind::ResultTypeMismatch(e.to_string())
                     )
                 )
             )
@@ -194,29 +238,26 @@ impl ClientCommandSender {
         T: TryFrom<RpcValue, Error = E>,
         E: std::fmt::Display,
     {
-        let communication_error = |err: &str| {
-            CallRpcMethodError::CommunicationError(Self::format_call_rpc_err(path, method, err))
-        };
-        let data_error = |err: &str| {
-            CallRpcMethodError::DataError(Self::format_call_rpc_err(path, method, err))
+        let make_error = |error_kind: CallRpcMethodErrorKind| {
+            CallRpcMethodError::new(path, method, error_kind)
         };
 
+        use CallRpcMethodErrorKind::*;
         self.do_rpc_call_param(path, method, param)
-            .map_err(|err| communication_error(&err.to_string()))?
+            .unwrap_or_else(|err|
+                panic!("Cannot send RPC request to the client core. \
+                    Path: `{path}`, method: `{method}`, error: {err}")
+            )
             .next()
             .await
-            .ok_or_else(|| communication_error("could not receive RpcFrame"))?
+            .ok_or_else(|| make_error(ConnectionClosed))?
             .to_rpcmesage()
-            .map_err(|e| data_error(&e.to_string()))?
+            .map_err(|e| make_error(InvalidMessage(e.to_string())))?
             .result()
-            .map_err(|e| data_error(&e.to_string()))
+            .map_err(|e| make_error(RpcError(e)))
             .cloned()
             .and_then(|r|
-                T::try_from(r).map_err(|e|
-                    CallRpcMethodError::DataError(
-                        Self::format_call_rpc_err(path, method, e)
-                    )
-                )
+                T::try_from(r).map_err(|e| make_error(ResultTypeMismatch(e.to_string())))
             )
     }
 

--- a/src/clientnode.rs
+++ b/src/clientnode.rs
@@ -29,7 +29,7 @@ fn dir<'a>(methods: impl IntoIterator<Item = &'a MetaMethod>, param: DirParam) -
             DirParam::Full => {
                 lst.push(mm.to_rpcvalue(metamethod::DirFormat::Map));
             }
-            DirParam::BriefMethod(ref method_name) => {
+            DirParam::Exists(ref method_name) => {
                 if mm.name == method_name {
                     result = mm.to_rpcvalue(metamethod::DirFormat::IMap);
                     break;

--- a/src/clientnode.rs
+++ b/src/clientnode.rs
@@ -4,6 +4,7 @@
 use crate::client::{RequestHandler, ClientCommandSender, MethodsGetter, AppState};
 use crate::runtime::spawn_task;
 use log::{error, debug};
+use shvrpc::rpcdiscovery::{DirParam, LsParam};
 use shvrpc::rpcframe::RpcFrame;
 use shvrpc::{metamethod, RpcMessage, RpcMessageMetaTags};
 use shvproto::rpcvalue;
@@ -16,27 +17,6 @@ pub use shvrpc::metamethod::{AccessLevel, Flag, MetaMethod};
 pub use shvrpc::rpcmessage::{RpcError, RpcErrorCode};
 pub use shvproto::{RpcValue, Value};
 
-enum DirParam {
-    Brief,
-    Full,
-    BriefMethod(String),
-}
-impl From<Option<&RpcValue>> for DirParam {
-    fn from(value: Option<&RpcValue>) -> Self {
-        match value {
-            Some(rpcval) => {
-                if rpcval.is_string() {
-                    DirParam::BriefMethod(rpcval.as_str().into())
-                } else if rpcval.as_bool() {
-                    DirParam::Full
-                } else {
-                    DirParam::Brief
-                }
-            }
-            None => DirParam::Brief,
-        }
-    }
-}
 
 fn dir<'a>(methods: impl IntoIterator<Item = &'a MetaMethod>, param: DirParam) -> RpcValue {
     let mut result = RpcValue::null();
@@ -61,25 +41,6 @@ fn dir<'a>(methods: impl IntoIterator<Item = &'a MetaMethod>, param: DirParam) -
         lst.into()
     } else {
         result
-    }
-}
-
-pub(crate) enum LsParam {
-    List,
-    Exists(String),
-}
-impl From<Option<&RpcValue>> for LsParam {
-    fn from(value: Option<&RpcValue>) -> Self {
-        match value {
-            Some(rpcval) => {
-                if rpcval.is_string() {
-                    LsParam::Exists(rpcval.as_str().into())
-                } else {
-                    LsParam::List
-                }
-            }
-            None => LsParam::List,
-        }
     }
 }
 


### PR DESCRIPTION
This patch adds wrappers for `do_rpc_call()` allowing users to just await final result of a RPC call without long and verbose error handling.

Special methods are implemented for `ls` and `dir`.