### PR TITLE
Delegate frame writes to a dedicated task

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvclient"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
`FrameWriter::send_message()` can block, so it is moved to a separate task to prevent blocking of connection task.