### PR TITLE
Introduce plain client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvclient"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2021"
 
 [lib]

--- a/src/examples/simple_device_async_std.rs
+++ b/src/examples/simple_device_async_std.rs
@@ -184,7 +184,8 @@ pub(crate) async fn main() -> shvrpc::Result<()> {
         async_std::task::spawn(emit_chng_task(client_cmd_tx, client_evt_rx, counter));
     };
 
-    shvclient::Client::new_device(DotAppNode::new("simple_device_async_std"), DotDeviceNode::new("simple_device", "0.1", Some("00000".into())))
+    shvclient::Client::new(DotAppNode::new("simple_device_async_std"))
+        .device(DotDeviceNode::new("simple_device", "0.1", Some("00000".into())))
         .mount("status/delayed", ClientNode::fixed(
                 DELAY_METHODS,
                 [Route::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,4 @@ pub use client::{
     RequestHandler,
 };
 pub use clientnode::Route;
+pub use connection::ConnectionFailedKind;


### PR DESCRIPTION
The client now comes in two variants, `full` and `plain`.

A plain client can only use client command and event channels to call RPC methods, recive notifications from subscriptions, watch client events and terminate the client at the end of communication. It does not export any nodes to be mounted on the broker.