### PR TITLE
client: Make CallRpcMethodError constructor public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvclient"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 
 [lib]

--- a/src/client.rs
+++ b/src/client.rs
@@ -108,7 +108,7 @@ pub struct CallRpcMethodError {
 }
 
 impl CallRpcMethodError {
-    fn new(path: &str, method: &str, error: CallRpcMethodErrorKind) -> Self {
+    pub fn new(path: &str, method: &str, error: CallRpcMethodErrorKind) -> Self {
         Self {
             path: path.to_owned(),
             method: method.to_owned(),


### PR DESCRIPTION
Users might need to create error values for testing.