### PR TITLE
Use fully qualified path for AppState in fixed_node macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvclient"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2021"
 
 [lib]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -72,7 +72,7 @@ macro_rules! fixed_node {
                     let mut __resp = $request.prepare_response().unwrap_or_default();
                     $(let $app_state = $app_state.expect("Application state should be Some");)?
 
-                    async fn handler($request: ::shvrpc::rpcmessage::RpcMessage, $client_cmd_tx: $crate::ClientCommandSender $(, $app_state: AppState<$T>)?)
+                    async fn handler($request: ::shvrpc::rpcmessage::RpcMessage, $client_cmd_tx: $crate::ClientCommandSender $(, $app_state: $crate::AppState<$T>)?)
                     -> Option<std::result::Result<$crate::clientnode::RpcValue, $crate::clientnode::RpcError>> {
                         match $request.method() {
 


### PR DESCRIPTION
Users of this macro should not need to import the AppState.