### PR TITLE
Return error response on ill-formed fixed_node handler implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvclient"
-version = "0.3.19"
+version = "0.3.20"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
If `app_state` is declared in a `fixed_node` macro handler but the client is created  without any state, the code returns an internal error message instead of just panicking the handler task. This informs the caller of the failure instead of causing a timeout.