### PR TITLE
Adjust subscriptions implementation to SHV API version 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvclient"
-version = "0.3.20"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/src/client.rs
+++ b/src/client.rs
@@ -253,10 +253,11 @@ impl ClientCommandSender {
 
         use CallRpcMethodErrorKind::*;
         self.do_rpc_call_param(path, method, param)
-            .unwrap_or_else(|err|
-                panic!("Cannot send RPC request to the client core. \
-                    Path: `{path}`, method: `{method}`, error: {err}")
-            )
+            .map_err(|err| {
+                warn!("Cannot send RPC request to the client core. \
+                    Path: `{path}`, method: `{method}`, error: {err}");
+                make_error(ConnectionClosed)
+            })?
             .next()
             .await
             .ok_or_else(|| make_error(ConnectionClosed))?

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -55,6 +55,11 @@ pub enum ConnectionFailedKind {
     LoginFailed,
 }
 
+pub(crate) enum ShvApiVersion {
+    V2,
+    V3,
+}
+
 pub(crate) enum ConnectionEvent {
     ConnectionFailed(ConnectionFailedKind),
     Connected(Sender<ConnectionCommand>),
@@ -155,6 +160,47 @@ async fn connection_loop(
     };
     info!("Login OK, client ID: {client_id}");
 
+    async fn check_shv_api_version(
+        frame_reader: &mut (dyn FrameReader + Send),
+        frame_writer: &mut (dyn FrameWriter + Send),
+    ) -> shvrpc::Result<ShvApiVersion>
+    {
+        let rq = RpcMessage::new_request(".broker", "ls", None);
+        frame_writer.send_message(rq).await?;
+        let resp = frame_reader.receive_message().await?;
+        let api_version = resp
+            .result()?
+            .as_list()
+            .into_iter()
+            .find_map(|node| match node.as_str() {
+                "app" => Some(ShvApiVersion::V2),
+                "client" => Some(ShvApiVersion::V3),
+                _ => None,
+            }
+            )
+            .unwrap_or_else(|| {
+                warn!("Cannot detect SHV API version. Using version 2 as a fallback.");
+                ShvApiVersion::V2
+            });
+        Ok(api_version)
+    }
+
+    let shv_api_version = match check_shv_api_version(&mut frame_reader, &mut frame_writer).await {
+        Ok(version) => version,
+        Err(err) => {
+            warn!("Error occured while checking SHV API version: {err}");
+            conn_event_sender
+                .unbounded_send(ConnectionEvent::ConnectionFailed(ConnectionFailedKind::NetworkError))
+                .unwrap_or_else(|e| debug!("ConnectionEvent::ConnectionFailed(NetworkError) send failed: {e}"));
+            return ConnectionLoopResult::ConnectionClosed;
+        }
+    };
+
+    let broker_app_path = match shv_api_version {
+        ShvApiVersion::V2 => ".broker/app",
+        ShvApiVersion::V3 => ".app",
+    };
+
     let (writer_tx, mut writer_rx) = futures::channel::mpsc::unbounded();
     let _writer_task = crate::runtime::spawn_task(async move {
         debug!("Writer task start");
@@ -186,7 +232,7 @@ async fn connection_loop(
             select! {
                 _ = fut_heartbeat_timeout => {
                     // send heartbeat
-                    let message = RpcMessage::new_request(".app", METH_PING, None);
+                    let message = RpcMessage::new_request(broker_app_path, METH_PING, None);
                     // reset heartbeat timer
                     fut_heartbeat_timeout = futures_time::task::sleep(heartbeat_interval.into()).fuse();
                     if let Err(err) = writer_tx.unbounded_send(message) {

--- a/src/examples/simple_device_async_std.rs
+++ b/src/examples/simple_device_async_std.rs
@@ -138,7 +138,7 @@ async fn emit_chng_task(
                 Ok(ClientEvent::ConnectionFailed(_)) => {
                     warn!("Connection failed");
                 }
-                Ok(ClientEvent::Connected) => {
+                Ok(ClientEvent::Connected(_)) => {
                     emit_signal = true;
                     warn!("Device connected");
                 },

--- a/src/examples/simple_device_tokio.rs
+++ b/src/examples/simple_device_tokio.rs
@@ -97,7 +97,7 @@ async fn emit_chng_task(
                 Some(ClientEvent::ConnectionFailed(_)) => {
                     info!("Connection failed");
                 }
-                Some(ClientEvent::Connected) => {
+                Some(ClientEvent::Connected(_)) => {
                     emit_signal = true;
                     info!("Device connected");
                 },


### PR DESCRIPTION
(#29, #33)

The implementation uses SHV Resource Identifiers (RI) instead of
path prefix, signal tuple. The Subscribe procedure is also made more robust
by waiting for subscription result before returning the Subscriber, so
the caller is notified about a failure instead of just not receiving any
notification.

The format of RI for subscriptions on SHV API v2 is `path_prefix:*:signal`
where `path_prefix` has the same meaning as the `path` param of subscribe
method in SHV2. No glob patterns are supported. The middle field (source)
is ignored and should be set to '*'. Any two subscriptions with the same
`path_prefix` and `signal` fields are equivalent.

The client user gets the SHV API version in the `Connected` client event.
