### PR TITLE
Improve MetaMethods manipulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvclient"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 [lib]
@@ -23,8 +23,8 @@ simple_logger = { version = "5.0.0", features = ["stderr"] }
 generics-alias = { git = "https://github.com/j4r0u53k/generics-alias-rs.git", branch = "main" }
 
 [dependencies]
-shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs", branch = "master", version = "3.1.0" }
-shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs", branch = "master", version = "3.1.0" }
+shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs", branch = "master", version = "3.2" }
+shvrpc = { git = "https://github.com/silicon-heaven/libshvrpc-rs", branch = "master", version = "3.2" }
 futures = "0.3.29"
 futures-time = "3.0.0"
 url = "2.4.1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,6 +13,7 @@ use shvrpc::rpcframe::RpcFrame;
 use shvrpc::rpcmessage::{RpcError, RpcErrorCode, RqId};
 use shvrpc::{RpcMessage, RpcMessageMetaTags};
 use shvproto::RpcValue;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -340,15 +341,17 @@ pub const BROKER_APP_NODE: &str = ".broker/app";
 pub const BROKER_CLIENT_NODE: &str = ".broker/client";
 pub const BROKER_CURRENT_CLIENT_NODE: &str = ".broker/currentClient";
 
+pub type MetaMethods = Cow<'static, [&'static MetaMethod]>;
+
 // The wrapping struct itself is descriptive
 #[allow(clippy::type_complexity)]
-pub struct MethodsGetter<T>(pub(crate) Box<dyn Fn(String, Option<AppState<T>>) -> BoxFuture<'static, Option<Vec<&'static MetaMethod>>> + Sync + Send>);
+pub struct MethodsGetter<T>(pub(crate) Box<dyn Fn(String, Option<AppState<T>>) -> BoxFuture<'static, Option<MetaMethods>> + Sync + Send>);
 
 impl<T> MethodsGetter<T> {
     pub fn new<F, Fut>(func: F) -> Self
     where
         F: Fn(String, Option<AppState<T>>) -> Fut + Sync + Send + 'static,
-        Fut: Future<Output=Option<Vec<&'static MetaMethod>>> + Send + 'static,
+        Fut: Future<Output=Option<MetaMethods>> + Send + 'static,
     {
         Self(Box::new(move |path, data| Box::pin(func(path, data))))
     }
@@ -1573,9 +1576,9 @@ mod tests {
         // Request handling tests
         //
         pub(super) fn make_client_with_handlers() -> Client<Full,()> {
-            async fn methods_getter(path: String, _: Option<AppState<()>>) -> Option<Vec<&'static MetaMethod>> {
+            async fn methods_getter(path: String, _: Option<AppState<()>>) -> Option<MetaMethods> {
                 if path.is_empty() {
-                    Some(PROPERTY_METHODS.iter().collect())
+                    Some(MetaMethods::from(&PROPERTY_METHODS))
                 } else {
                     None
                 }
@@ -1610,7 +1613,7 @@ mod tests {
                     MethodsGetter::new(methods_getter),
                     RequestHandler::stateless(request_handler))
                 .mount_fixed("static",
-                    PROPERTY_METHODS.iter(),
+                    PROPERTY_METHODS,
                     [Route::new([crate::clientnode::METH_GET, crate::clientnode::METH_SET],
                         RequestHandler::stateless(request_handler))])
         }

--- a/src/clientnode.rs
+++ b/src/clientnode.rs
@@ -8,6 +8,7 @@ use shvrpc::rpcdiscovery::{DirParam, LsParam};
 use shvrpc::rpcframe::RpcFrame;
 use shvrpc::{metamethod, RpcMessage, RpcMessageMetaTags};
 use shvproto::rpcvalue;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::format;
 use std::sync::Arc;
@@ -75,7 +76,7 @@ pub(crate) fn process_local_dir_ls<V>(
     if method == METH_DIR && !is_mount_point {
         // dir in the middle of the tree must be resolved locally
         if let Ok(rpcmsg) = frame.to_rpcmesage() {
-            let dir = dir(DIR_LS_METHODS.iter(), rpcmsg.param().into());
+            let dir = dir(DIR_LS_METHODS, rpcmsg.param().into());
             return Some(RequestResult::Response(dir));
         } else {
             return Some(RequestResult::Error(RpcError::new(
@@ -212,7 +213,7 @@ struct FixedNode<'a, T> {
 
 impl<'a, T> FixedNode<'a, T> {
     fn new(methods: impl IntoIterator<Item = &'a MetaMethod>, routes: impl IntoIterator<Item = Route<T>>) -> Self {
-        let methods = DIR_LS_METHODS.iter().chain(methods).collect::<Vec<&MetaMethod>>();
+        let methods = DIR_LS_METHODS.into_iter().chain(methods).collect::<Vec<&MetaMethod>>();
         let handlers = Self::add_routes(&methods, routes);
         Self {
             methods,
@@ -325,12 +326,16 @@ impl<'a, T: Sync + Send + 'static> ClientNode<'a, T> {
                 spawn_task(async move {
                     let methods = node.methods.0(shv_path, app_state.clone()).await
                         .map_or_else(
-                            Vec::new,
-                            |m| DIR_LS_METHODS.iter().chain(m).collect());
+                            || Cow::from(&[]),
+                            |m| if m.is_empty() {
+                                Cow::from(&DIR_LS_METHODS)
+                            } else {
+                                DIR_LS_METHODS.into_iter().chain(m.iter().copied()).collect()
+                            });
                     if resolve_request_access(&request, &mount_path, &client_cmd_tx, &methods) {
                         match request.method() {
                             Some(self::METH_DIR) => {
-                                let result = dir(methods.into_iter(), request.param().into());
+                                let result = dir(methods.iter().copied(), request.param().into());
                                 send_response(request, client_cmd_tx, Ok(result));
                             }
                             Some(_) =>
@@ -343,11 +348,11 @@ impl<'a, T: Sync + Send + 'static> ClientNode<'a, T> {
             },
             NodeVariant::Constant(node) => {
                 let methods = if request.shv_path().unwrap_or_default().is_empty() {
-                    DIR_LS_METHODS.iter().chain(node.methods()).collect()
+                    DIR_LS_METHODS.into_iter().chain(node.methods()).collect()
                 } else {
                     // Static nodes do not have any own children. Any child nodes are
                     // resolved on the mounts tree level in `process_local_dir_ls()`.
-                    vec![]
+                    Cow::from(&[])
                 };
                 if resolve_request_access(&request, &mount_path, &client_cmd_tx, &methods) {
                     let Some(method) = request.method() else {
@@ -450,8 +455,8 @@ pub const METH_SET: &str = "set";
 pub const SIG_CHNG: &str = "chng";
 pub const METH_PING: &str = "ping";
 
-pub(crate) const DIR_LS_METHODS: [MetaMethod; 2] = [
-    MetaMethod {
+pub(crate) const DIR_LS_METHODS: [&MetaMethod; 2] = [
+    &MetaMethod {
         name: METH_DIR,
         flags: Flag::None as u32,
         access: AccessLevel::Browse,
@@ -460,7 +465,7 @@ pub(crate) const DIR_LS_METHODS: [MetaMethod; 2] = [
         signals: &[],
         description: "",
     },
-    MetaMethod {
+    &MetaMethod {
         name: METH_LS,
         flags: Flag::None as u32,
         access: AccessLevel::Browse,
@@ -468,10 +473,10 @@ pub(crate) const DIR_LS_METHODS: [MetaMethod; 2] = [
         result: "LsResult",
         signals: &[],
         description: "",
-    },
+    }
 ];
-pub const PROPERTY_METHODS: [MetaMethod; 3] = [
-    MetaMethod {
+
+pub const META_METHOD_GET: MetaMethod = MetaMethod {
         name: METH_GET,
         flags: Flag::IsGetter as u32,
         access: AccessLevel::Read,
@@ -479,8 +484,9 @@ pub const PROPERTY_METHODS: [MetaMethod; 3] = [
         result: "",
         signals: &[],
         description: "",
-    },
-    MetaMethod {
+    };
+
+pub const META_METHOD_SET: MetaMethod = MetaMethod {
         name: METH_SET,
         flags: Flag::IsSetter as u32,
         access: AccessLevel::Write,
@@ -488,8 +494,9 @@ pub const PROPERTY_METHODS: [MetaMethod; 3] = [
         result: "",
         signals: &[],
         description: "",
-    },
-    MetaMethod {
+    };
+
+pub const META_METHOD_SIG_CHNG: MetaMethod = MetaMethod {
         name: SIG_CHNG,
         flags: Flag::IsSignal as u32,
         access: AccessLevel::Read,
@@ -497,7 +504,12 @@ pub const PROPERTY_METHODS: [MetaMethod; 3] = [
         result: "",
         signals: &[],
         description: "",
-    },
+    };
+
+pub const PROPERTY_METHODS: [&MetaMethod; 3] = [
+    &META_METHOD_GET,
+    &META_METHOD_SET,
+    &META_METHOD_SIG_CHNG,
 ];
 
 
@@ -541,46 +553,67 @@ mod tests {
 
     #[test]
     fn accept_valid_routes() {
-        ClientNode::fixed(&PROPERTY_METHODS,
-                            vec![Route::new([METH_GET, METH_SET, METH_LS], RequestHandler::stateful(dummy_handler))]);
+        ClientNode::fixed(PROPERTY_METHODS,
+                            [Route::new([METH_GET, METH_SET, METH_LS], RequestHandler::stateful(dummy_handler))]);
     }
 
     #[test]
     fn accept_valid_routes_without_ls() {
-        ClientNode::fixed(&PROPERTY_METHODS,
-                            vec![Route::new([METH_GET, METH_SET], RequestHandler::stateful(dummy_handler))]);
+        ClientNode::fixed(PROPERTY_METHODS,
+                            [Route::new([METH_GET, METH_SET], RequestHandler::stateful(dummy_handler))]);
     }
 
     #[test]
     #[should_panic]
     fn reject_sig_chng_route() {
-        ClientNode::fixed(&PROPERTY_METHODS,
-                            vec![Route::new([METH_GET, METH_SET, METH_LS, SIG_CHNG], RequestHandler::stateful(dummy_handler))]);
+        ClientNode::fixed(PROPERTY_METHODS,
+                            [Route::new([METH_GET, METH_SET, METH_LS, SIG_CHNG], RequestHandler::stateful(dummy_handler))]);
     }
 
     #[test]
     #[should_panic]
     fn reject_custom_dir_handler() {
-        ClientNode::fixed(&PROPERTY_METHODS,
-                            vec![Route::new([METH_GET, METH_SET, METH_DIR], RequestHandler::stateful(dummy_handler))]);
+        ClientNode::fixed(PROPERTY_METHODS,
+                            [Route::new([METH_GET, METH_SET, METH_DIR], RequestHandler::stateful(dummy_handler))]);
     }
 
     #[test]
     #[should_panic]
     fn reject_invalid_method_route() {
-        ClientNode::fixed(&PROPERTY_METHODS, vec![Route::new(["invalidMethod"], RequestHandler::stateful(dummy_handler))]);
+        ClientNode::fixed(PROPERTY_METHODS, [Route::new(["invalidMethod"], RequestHandler::stateful(dummy_handler))]);
     }
 
     #[test]
     #[should_panic]
     fn reject_unhandled_method() {
-        ClientNode::fixed(&PROPERTY_METHODS, vec![Route::new([METH_GET], RequestHandler::stateful(dummy_handler))]);
+        ClientNode::fixed(PROPERTY_METHODS, [Route::new([METH_GET], RequestHandler::stateful(dummy_handler))]);
     }
 
     #[test]
     #[should_panic]
     fn reject_duplicate_method() {
-        let duplicate_methods = PROPERTY_METHODS.iter().chain(DIR_LS_METHODS.iter());
-        ClientNode::fixed(duplicate_methods, vec![Route::new([METH_GET, METH_SET, METH_LS], RequestHandler::stateful(dummy_handler))]);
+        let duplicate_methods = PROPERTY_METHODS.into_iter().chain(DIR_LS_METHODS);
+        ClientNode::fixed(duplicate_methods, [Route::new([METH_GET, METH_SET, METH_LS], RequestHandler::stateful(dummy_handler))]);
+    }
+
+    #[test]
+    fn create_fixed_node() {
+        let node: crate::clientnode::ClientNode<'_, ()> = crate::fixed_node!{
+            device_handler(request, _tx) {
+                "echo" [IsGetter, Browse, "", ""] (param: i32) => {
+                    Some(Ok(param.into()))
+                }
+            }
+        };
+
+        let NodeVariant::Fixed(FixedNode { methods, handlers }) = node.0 else {
+            panic!("Not a fixed node");
+        };
+        assert_eq!(methods.len(), 3, "Expected 3 methods");
+        assert_eq!(methods[0].name, "dir");
+        assert_eq!(methods[1].name, "ls");
+        assert_eq!(methods[2].name, "echo");
+        assert_eq!(handlers.len(), 1, "Expected 1 handler");
+
     }
 }

--- a/src/examples/simple_device_tokio.rs
+++ b/src/examples/simple_device_tokio.rs
@@ -1,10 +1,10 @@
 use shvclient::appnodes::DotAppNode;
+use shvclient::client::MetaMethods;
 use tokio::sync::RwLock;
 
 use clap::Parser;
 use futures::{select, FutureExt, StreamExt};
 use log::*;
-use shvrpc::metamethod::MetaMethod;
 use shvrpc::{client::ClientConfig, util::parse_log_verbosity};
 use shvrpc::RpcMessage;
 use shvclient::{MethodsGetter, RequestHandler};
@@ -151,8 +151,8 @@ pub(crate) async fn main() -> shvrpc::Result<()> {
         tokio::task::spawn(emit_chng_task(client_cmd_tx, client_evt_rx, counter));
     };
 
-    async fn dyn_methods_getter(_path: String, _: Option<AppState<RwLock<i32>>>) -> Option<Vec<&'static MetaMethod>> {
-        Some(PROPERTY_METHODS.iter().collect())
+    async fn dyn_methods_getter(_path: String, _: Option<AppState<RwLock<i32>>>) -> Option<MetaMethods> {
+        Some(MetaMethods::from(&PROPERTY_METHODS))
     }
     async fn dyn_handler(_request: RpcMessage, _client_cmd_tx: ClientCommandSender) {
     }


### PR DESCRIPTION
Changed methods definition from [MetaMethod] to [&MetaMethod].

Replaced Vector with Cow in MethodsGetter return value.

These changes eliminates the need for call to `.iter().collect()` when returning methods from a MethodsGetter. Instead, implementors can use `MetaMethods::from(&methods)` or `MetaMethods::from(methods)`.